### PR TITLE
Adding option to return un-rounded values from `px()` , with tests

### DIFF
--- a/sphericalmercator.js
+++ b/sphericalmercator.js
@@ -40,11 +40,19 @@ function SphericalMercator(options) {
 //
 // - `ll` {Array} `[lon, lat]` array of geographic coordinates.
 // - `zoom` {Number} zoom level.
-SphericalMercator.prototype.px = function(ll, zoom) {
+SphericalMercator.prototype.px = function(ll, zoom, round) {
+    if(round === undefined) round = true;
+
     var d = this.zc[zoom];
     var f = Math.min(Math.max(Math.sin(D2R * ll[1]), -0.9999), 0.9999);
-    var x = Math.round(d + ll[0] * this.Bc[zoom]);
-    var y = Math.round(d + 0.5 * Math.log((1 + f) / (1 - f)) * (-this.Cc[zoom]));
+    var x = d + ll[0] * this.Bc[zoom];
+    var y = d + 0.5 * Math.log((1 + f) / (1 - f)) * (-this.Cc[zoom]);
+    
+    if(round) {
+        x = Math.round(x);
+        y = Math.round(y);
+    }
+
     (x > this.Ac[zoom]) && (x = this.Ac[zoom]);
     (y > this.Ac[zoom]) && (y = this.Ac[zoom]);
     //(x < 0) && (x = 0);

--- a/test/sphericalmercator.test.js
+++ b/test/sphericalmercator.test.js
@@ -81,6 +81,25 @@ tape('convert', function(assert) {
     assert.end();
 });
 
+tape('px', function(assert) {
+    assert.deepEqual(
+        sm.px([-122,36], 0),
+        [ 41, 101 ]
+    );
+
+    assert.deepEqual(
+        sm.px([-122,36], 0, false),
+        [ 41.24444444444444, 100.52754553089112 ]
+    );
+
+    assert.deepEqual(
+        sm.px([122,36], 0),
+        [ 215, 101 ]
+    );
+    
+    assert.end();
+});
+
 tape('extents', function(assert) {
     assert.deepEqual(
         sm.convert([-240,-90,240,90],'900913'),


### PR DESCRIPTION
This PR adds an option to return full precision un-rounded pixel values from the `px()` method. This is useful for placing points on a spherical mercator coordinate system that does not have a concept of zoom levels and needs full precision for each point.

I added some quick basic tests for this method because there were none before.