### PR TITLE
Support both CJS and ESM imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ const merc = new SphericalMercator({
 });
 ```
 
+or, for CommonJS:
+
+```javascript
+const { SphericalMercator } = require('@mapbox/sphericalmercator');
+```
+
 ### `px(ll, zoom)`
 
 Convert lon, lat to screen pixel x, y from 0, 0 origin, at a certain zoom level. The inverse of `ll`. If `antimeridian: true` is passed on initialization of the `SphericalMercator` object, this method will support converting longitude values up to 360°.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/sphericalmercator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/sphericalmercator",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@vitest/coverage-v8": "^2.1.1",
         "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "email": "info@mapbox.com"
   },
   "main": "dist/index.js",
+  "type": "module",
   "types": "dist/index.d.ts",
   "devDependencies": {
     "@vitest/coverage-v8": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,20 @@
     "url": "https://mapbox.com/",
     "email": "info@mapbox.com"
   },
-  "main": "dist/index.js",
   "type": "module",
-  "types": "dist/index.d.ts",
+  "files": ["/dist"],
+  "exports": {
+      ".": {
+          "require": {
+              "default": "./dist/cjs/index.js",
+              "types": "./dist/cjs/index.d.ts"
+          },
+          "import": {
+              "default": "./dist/esm/index.js",
+              "types": "./dist/esm/index.d.ts"
+          }
+      }
+  },
   "devDependencies": {
     "@vitest/coverage-v8": "^2.1.1",
     "ts-node": "^10.9.2",
@@ -34,7 +45,10 @@
   "scripts": {
     "test": "vitest --config ./vitest.config.ts --coverage run",
     "format": "npx prettier src test --write --single-quote",
-    "build": "tsc -p .",
+    "clean": "rm -rf ./dist",
+    "build-cjs": "tsc -p . --module commonjs --outDir ./dist/cjs && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",
+    "build-esm": "tsc -p . --module nodenext --outDir ./dist/esm && echo '{\"type\": \"module\"}' > ./dist/esm/package.json",
+    "build": "npm run clean && npm run build-cjs && npm run build-esm",
     "prepublishOnly": "npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/sphericalmercator",
   "description": "Transformations between the Web Mercator projection and Latitude Longitude coordinates",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "licenses": [
     {
       "type": "BSD"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   MAXEXTENT,
   SPHERICAL_MERCATOR_SRS,
   WGS84,
-} from './constants';
+} from './constants.js';
 
 interface Options {
   size?: number;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import { SphericalMercator } from '../src';
+import { SphericalMercator } from '../src/index.js';
 
 const MAX_EXTENT_MERC = [
   -20037508.342789244, -20037508.342789244, 20037508.342789244,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,10 @@
     "lib": ["ESNext"] /* Specify library files to be included in the compilation. */,
 
     /* Modules */
-    "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "module": "NodeNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
 
     /* Emit */
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "outDir": "./dist/esm" /* Specify an output folder for all emitted files. */,
 
     "types": [
       "vitest/importMeta"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,11 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
     /* Language and Environment */
-    "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
-    "lib": ["ESNEXT"] /* Specify library files to be included in the compilation. */,
+    "target": "ESNext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
+    "lib": ["ESNext"] /* Specify library files to be included in the compilation. */,
 
     /* Modules */
-    "module": "ESNEXT" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
 
     /* Emit */


### PR DESCRIPTION
This fixes ESM imports that were broken by the TypeScript upgrade in #45 (`v2.0.0`).

Closes #46 

cc @MattIPv4 - Can you confirm this fixes your issue?

```
git clone git@github.com:mapbox/sphericalmercator.git && cd sphericalmercator
git checkout greenlaw/fix-esm-import
cd ..
mkdir smtest && cd smtest
npm init -y
npm pkg set type=module
npm link ../sphericalmercator
echo "import { SphericalMercator } from '@mapbox/sphericalmercator';" > index.js
node index.js
```

Edit: Both CJS and ESM imports are now supported.